### PR TITLE
Convert OMERO strings to unicode

### DIFF
--- a/.omeroci/lib-test
+++ b/.omeroci/lib-test
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eux
+
+docker run --link $CID:omero --net $NETWORK --rm -d -p 9449:9449 --name omero-prometheus-tools test -s omero -u root -w omero -c /opt/omero-prometheus-tools/etc/prometheus-omero-counts.yml -v
+sleep 10
+./test.py
+if [ "$NOCLEAN" != "true" ]; then
+    docker rm -f omero-prometheus-tools
+fi

--- a/.omeroci/omero-init
+++ b/.omeroci/omero-init
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eu
+
+OMERO=/opt/omero/server/OMERO.server/bin/omero
+$OMERO login -C -s localhost -u root -w omero
+$OMERO group add "بيئة مجهرية مفتوحة"
+$OMERO user add -P ome микроскопом-пони микроскопом пони "بيئة مجهرية مفتوحة"
+# Login as микроскопом-пони fails with a unicode error so create
+# an ascii username instead
+$OMERO user add -P ome test-user test user "بيئة مجهرية مفتوحة"
+$OMERO login -C -s localhost -u test-user -w ome
+$OMERO obj new Project name=project

--- a/.omeroci/test-data
+++ b/.omeroci/test-data
@@ -1,7 +1,7 @@
 #!/bin/bash
-set -eu
+set -eux
 
-OMERO=/opt/omero/server/OMERO.server/bin/omero
+OMERO=${OMERO_DIST:-/opt/omero/server/OMERO.server}/bin/omero
 $OMERO login -C -s localhost -u root -w omero
 $OMERO group add "بيئة مجهرية مفتوحة"
 $OMERO user add -P ome микроскопом-пони микроскопом пони "بيئة مجهرية مفتوحة"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,5 @@ services:
   - docker
 
 script:
-  - IP=`ip addr show eth0 | sed -nre 's/\s+inet ([0-9\.]+).*/\1/p'`
-  - echo $IP
-  - git clone --single-branch --branch setup-external git://github.com/manics/omero-test-infra .omero
-  - env "NOCLEAN=true" "OMERO_SERVER_SSL=4064:" .omero/docker setup
-  - docker build -t omero-prometheus-tools .
-  - docker run -d --rm --name omero-prometheus-tools -p 9449:9449 omero-prometheus-tools -s $IP -u root -w omero -c /opt/omero-prometheus-tools/etc/prometheus-omero-counts.yml -v
-  - sleep 10
-  - docker logs omero-prometheus-tools
-  - ./test.py
+  - git clone git://github.com/openmicroscopy/omero-test-infra .omero
+  - .omero/docker lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,12 @@ services:
   - docker
 
 script:
+  - IP=`ip addr show eth0 | sed -nre 's/\s+inet ([0-9\.]+).*/\1/p'`
+  - echo $IP
+  - git clone --single-branch --branch setup-external git://github.com/manics/omero-test-infra .omero
+  - env "NOCLEAN=true" "OMERO_SERVER_SSL=4064:" .omero/docker setup
   - docker build -t omero-prometheus-tools .
-  - docker run omero-prometheus-tools omero-prometheus-tools.py --help
+  - docker run -d --rm --name omero-prometheus-tools -p 9449:9449 omero-prometheus-tools -s $IP -u root -w omero -c /opt/omero-prometheus-tools/etc/prometheus-omero-counts.yml -v
+  - sleep 10
+  - docker logs omero-prometheus-tools
+  - ./test.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ COPY omero_prometheus_tools /opt/omero-prometheus-tools/omero_prometheus_tools/
 COPY etc /opt/omero-prometheus-tools/etc/
 RUN cd /opt/omero-prometheus-tools/ && \
     python setup.py install
+ENTRYPOINT ["/usr/bin/omero-prometheus-tools.py"]

--- a/omero_prometheus_tools/counts.py
+++ b/omero_prometheus_tools/counts.py
@@ -42,7 +42,9 @@ class QueryMetric(object):
         prev_labelsets = self.labelsets
         self.labelsets = set()
         for r in results:
-            labelvalues = unwrap(r[1:])
+            # OMERO unicode rstrings are not Python unicode
+            labelvalues = [
+                lv.decode('utf-8', 'replace') for lv in unwrap(r[1:])]
             value = unwrap(r[0])
             self.prometheus_gauge.labels(*labelvalues).set(value)
             self.labelsets.add(tuple(labelvalues))

--- a/omero_prometheus_tools/sessions.py
+++ b/omero_prometheus_tools/sessions.py
@@ -44,7 +44,8 @@ class SessionMetrics(object):
             cb = self.client.submit(
                 omero.cmd.CurrentSessionsRequest(), 60, 500)
             rsp = cb.loop(60, 500)
-            counts = collections.Counter(c.userName for c in rsp.contexts)
+            counts = collections.Counter(
+                c.userName.decode('utf-8', 'replace') for c in rsp.contexts)
             missing = self.lastusers.difference(counts.keys())
             for m in missing:
                 if self.verbose:

--- a/test.py
+++ b/test.py
@@ -12,3 +12,5 @@ assert vals['omero_groups_total'] == '4.0'
 assert vals['omero_sessions_active{username="test-user"}'] == '1.0'
 assert (vals[u'omero_counts_projects_total{group="بيئة مجهرية مفتوحة"}'] ==
         '1.0')
+
+print('PASSED')

--- a/test.py
+++ b/test.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from urllib2 import urlopen
+
+r = urlopen('http://localhost:9449')
+rsp = r.read().decode('utf-8')
+vals = dict(line.rsplit(' ', 1) for line in rsp.splitlines()
+            if not line.startswith('#'))
+
+assert vals['omero_groups_total'] == '4.0'
+assert vals['omero_sessions_active{username="test-user"}'] == '1.0'
+assert (vals[u'omero_counts_projects_total{group="بيئة مجهرية مفتوحة"}'] ==
+        '1.0')


### PR DESCRIPTION
Fixes https://trello.com/c/lLxHorjS/5609-prom-exporter-unicodedecodeerror

OMERO rstrings may contain unicode, but they are not automatically converted to Python unicode. This solution involved some trial-and-error.

Testing: `omero-prometheus-tools.py -s pub-omero.openmicroscopy.org -u PRIVILEGED-USER -w PASSWORD -v -c etc/prometheus-omero-counts.yml` against a server that has Unicode group names e.g. pub-omero and go to http://localhost:9449/

- [x] --depends-on https://github.com/openmicroscopy/omero-test-infra/pull/24