### PR TITLE
Bump version in setup.py 0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
     name='omero-prometheus-tools',
-    version='0.0.1',
+    version='0.1.2',
     scripts=[
         'omero_prometheus_tools/omero-prometheus-tools.py',
     ],


### PR DESCRIPTION
This wasn't bumped with the last releases so upgrades fail.