### PR TITLE
Fix deprecation warning from pyyaml

### DIFF
--- a/omero_prometheus_tools/counts.py
+++ b/omero_prometheus_tools/counts.py
@@ -64,7 +64,7 @@ class CountMetrics(object):
         self.metrics = {}
         for f in configfiles:
             with open(f) as fh:
-                cfg = yaml.load(fh)
+                cfg = yaml.load(fh, Loader=yaml.FullLoader)
             for name in cfg:
                 if name in self.metrics:
                     raise Exception(


### PR DESCRIPTION
See https://msg.pyyaml.org/load for more information.

Assuming we are only loading our very own `.yml` file I guess it is safe to simply specify the `FullLoader`.